### PR TITLE
APPENG-2457: entity-feedback - added overlay to provide the custom component wrapped in another component

### DIFF
--- a/plugins/entity-feedback/app-config.dynamic.yaml
+++ b/plugins/entity-feedback/app-config.dynamic.yaml
@@ -1,8 +1,19 @@
 dynamicPlugins:
   frontend:
     backstage.plugin-entity-feedback:
-      # For showing in the overview tab
+      # For showing in the overview tab. Use either of the two mountPoints
       mountPoints:
+        - mountPoint: entity.page.overview/cards
+          module: CustomRoot                  # This is the key for "exposedModules" element in "scalprum-config.json"
+          importName: CustomLikeDislikeCard   # Custom component where "InfoCard" wraps "LikeDislikeButtons" 
+          config:
+            layout:
+              boxShadow: 10
+              gridColumn: "1 / -1"
+              gridRow: '2 / 3'
+              width: 20vw
+            props:
+              text: "Entity Feedback CustomLikeDislikeCard content would be here"
         - mountPoint: entity.page.overview/cards
           # Component for Feedback Like Dislike buttons
           importName: EntityLikeDislikeRatingsCard
@@ -10,5 +21,6 @@ dynamicPlugins:
           # importName: EntityFeedbackResponseContent
           config:
             layout:
-              gridColumn: "1 / -1"
-              width: 50vw
+              boxShadow: 5
+              gridRow: '2 / 3'
+              gridColumn: "8 / -1"

--- a/plugins/entity-feedback/overlay/src/custom-component.tsx
+++ b/plugins/entity-feedback/overlay/src/custom-component.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import {InfoCard} from '@backstage/core-components';
+import { LikeDislikeButtons } from '@backstage/plugin-entity-feedback';
+
+export const CustomLikeDislikeCard = () => (
+    <InfoCard title="Rate this entity">
+       <LikeDislikeButtons/>
+    </InfoCard>
+  );

--- a/plugins/entity-feedback/overlay/src/custom.ts
+++ b/plugins/entity-feedback/overlay/src/custom.ts
@@ -1,0 +1,3 @@
+export * from '@backstage/plugin-entity-feedback';
+
+export {CustomLikeDislikeCard} from './custom-component';

--- a/plugins/entity-feedback/scalprum-config.json
+++ b/plugins/entity-feedback/scalprum-config.json
@@ -1,0 +1,7 @@
+{
+  "name": "backstage.plugin-entity-feedback",
+  "exposedModules": {
+    "PluginRoot": "./src/index.ts",
+    "CustomRoot": "./src/custom.ts"
+  }
+}


### PR DESCRIPTION
I've successfully tested it locally (with Janus codebase) as well as in RHDH, using the artifact generated from my forked repo. Attached screenshot is from my RHDH instance.

![Entity-feedback-cards-in-RHDH](https://github.com/davidfestal/backstage-plugins-dynamic-build/assets/2349910/3a2f6af3-da6a-40c7-84cd-966ffb896ced)
