### PR TITLE
Removing catalog-backend-module-bitbucket

### DIFF
--- a/plugins-list.yaml
+++ b/plugins-list.yaml
@@ -26,7 +26,6 @@ plugins/auth-backend-module-vmware-cloud-provider:
 plugins/catalog-backend-module-aws:
 plugins/catalog-backend-module-azure:
 plugins/catalog-backend-module-backstage-openapi:
-plugins/catalog-backend-module-bitbucket:
 # plugins/catalog-backend-module-bitbucket-cloud  ==> already embedded in RHDH
 # plugins/catalog-backend-module-bitbucket-server  ==> already embedded in RHDH
 plugins/catalog-backend-module-gcp:


### PR DESCRIPTION
Found that `catalog-backend-module-bitbucket` is not a plugin